### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 An integration that allows LLMs to interact with Raindrop.io bookmarks using the Model Context Protocol (MCP).
 
+<a href="https://glama.ai/mcp/servers/@hiromitsusasaki/raindrop-io-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@hiromitsusasaki/raindrop-io-mcp-server/badge" alt="Raindrop.io Server MCP server" />
+</a>
+
 ## Features
 
 - Create bookmarks
@@ -112,7 +116,6 @@ This is an open source MCP server that anyone can use and contribute to. The pro
 ## Contributing
 
 Contributions are welcome! Feel free to submit issues, feature requests, or pull requests to help improve this project.
-
 
 ## Related Links
 


### PR DESCRIPTION
This PR adds a badge for the [Raindrop.io MCP Server](https://glama.ai/mcp/servers/@hiromitsusasaki/raindrop-io-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@hiromitsusasaki/raindrop-io-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@hiromitsusasaki/raindrop-io-mcp-server/badge" alt="Raindrop.io Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.