### PR TITLE
feat: implement bookmark update functionality

### DIFF
--- a/src/__tests__/raindrop.test.ts
+++ b/src/__tests__/raindrop.test.ts
@@ -109,6 +109,78 @@ describe("RaindropAPI", () => {
     });
   });
 
+  describe("updateBookmark", () => {
+    it("updates a bookmark", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ item: { _id: 123 } }),
+      } as Response);
+
+      const result = await api.updateBookmark(123, {
+        title: "Updated Title",
+        tags: ["updated", "test"],
+        collection: { $id: 456 },
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.raindrop.io/rest/v1/raindrop/123",
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer test-token`,
+          },
+          body: JSON.stringify({
+            title: "Updated Title",
+            tags: ["updated", "test"],
+            collection: { $id: 456 },
+          }),
+        },
+      );
+      expect(result).toEqual({ item: { _id: 123 } });
+    });
+
+    it("handles partial updates", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ item: { _id: 123 } }),
+      } as Response);
+
+      const result = await api.updateBookmark(123, {
+        title: "New Title Only",
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.raindrop.io/rest/v1/raindrop/123",
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer test-token`,
+          },
+          body: JSON.stringify({
+            title: "New Title Only",
+          }),
+        },
+      );
+      expect(result).toEqual({ item: { _id: 123 } });
+    });
+
+    it("handles update API errors", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        statusText: "Not found",
+        json: () => Promise.resolve({ error: "Not found" }),
+      } as Response);
+
+      await expect(
+        api.updateBookmark(999, {
+          title: "Non-existent bookmark",
+        }),
+      ).rejects.toThrow("Raindrop API error: Not found");
+    });
+  });
+
   describe("listCollections", () => {
     it("lists collections", async () => {
       mockFetch.mockResolvedValueOnce({

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, jest } from "@jest/globals";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { CallToolRequest } from "@modelcontextprotocol/sdk/types.js";
 import { RaindropAPI } from "../lib/raindrop-api.js";
 import { CreateBookmarkSchema, SearchBookmarksSchema, UpdateBookmarkSchema } from "../types/index.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import dotenv from "dotenv";
 import { z } from "zod";
 import { RaindropAPI } from "./lib/raindrop-api.js";
 import { tools } from "./lib/tools.js";
-import { CreateBookmarkSchema, SearchBookmarksSchema } from "./types/index.js";
+import { CreateBookmarkSchema, SearchBookmarksSchema, UpdateBookmarkSchema } from "./types/index.js";
 
 dotenv.config();
 
@@ -102,6 +102,32 @@ Last Updated: ${new Date(item.lastUpdate).toLocaleString()}
                       results.items.length
                     } on page ${page ?? 0 + 1}):\n${formattedResults}`
                   : "No bookmarks found matching your search.",
+            },
+          ],
+        };
+      }
+
+      if (name === "update-bookmark") {
+        const { id, title, tags, collection } =
+          UpdateBookmarkSchema.parse(args);
+
+        const updateParams: {
+          title?: string;
+          tags?: string[];
+          collection?: { $id: number };
+        } = {};
+
+        if (title !== undefined) updateParams.title = title;
+        if (tags !== undefined) updateParams.tags = tags;
+        if (collection !== undefined) updateParams.collection = { $id: collection };
+
+        const result = await api.updateBookmark(id, updateParams);
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Bookmark ${result.item._id} updated successfully`,
             },
           ],
         };

--- a/src/lib/raindrop-api.ts
+++ b/src/lib/raindrop-api.ts
@@ -55,4 +55,16 @@ export class RaindropAPI {
   async listCollections(): Promise<CollectionsResponse> {
     return this.makeRequest<CollectionsResponse>("/collections");
   }
+
+  async updateBookmark(id: number, params: {
+    title?: string;
+    tags?: string[];
+    collection?: { $id: number };
+  }) {
+    return this.makeRequest<{ item: { _id: number } }>(
+      `/raindrop/${id}`,
+      "PUT",
+      params,
+    );
+  }
 }

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -80,6 +80,33 @@ export const tools: Tool[] = [
     },
   },
   {
+    name: "update-bookmark",
+    description: "Update an existing bookmark in Raindrop.io",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "number",
+          description: "Bookmark ID to update",
+        },
+        title: {
+          type: "string",
+          description: "New title for the bookmark (optional)",
+        },
+        tags: {
+          type: "array",
+          items: { type: "string" },
+          description: "New tags for the bookmark (optional)",
+        },
+        collection: {
+          type: "number",
+          description: "New collection ID to move to (optional)",
+        },
+      },
+      required: ["id"],
+    },
+  },
+  {
     name: "list-collections",
     description: "List all your Raindrop.io collections",
     inputSchema: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,9 +29,17 @@ export const SearchBookmarksSchema = z.object({
   word: z.boolean().optional(),
 });
 
+export const UpdateBookmarkSchema = z.object({
+  id: z.number(),
+  title: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  collection: z.number().optional(),
+});
+
 // Zodスキーマから型を生成
 export type CreateBookmarkParams = z.infer<typeof CreateBookmarkSchema>;
 export type SearchBookmarksParams = z.infer<typeof SearchBookmarksSchema>;
+export type UpdateBookmarkParams = z.infer<typeof UpdateBookmarkSchema>;
 
 // APIレスポンスの型
 export interface RaindropItem {


### PR DESCRIPTION
## Summary
- Add update-bookmark tool with validation schema
- Implement PUT /raindrop/{id} API endpoint
- Support updating title, tags, and collection
- Add comprehensive tests for API and handlers
- Include proper error handling and validation

Closes #3

## Test plan
- [x] Unit tests for API method (full/partial updates, error handling)
- [x] Unit tests for tool handler (individual/multiple fields, validation)
- [x] Validation schema tests

Generated with [Claude Code](https://claude.ai/code)