### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ An integration that allows LLMs to interact with Raindrop.io bookmarks using the
 - Search bookmarks
 - Filter by tags
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/hiromitsusasaki-raindrop-io-mcp-server).
+
 ## Requirements
 
 - Node.js 16 or higher


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/hiromitsusasaki-raindrop-io-mcp-server).